### PR TITLE
Fix issue where we require a different file than we check for

### DIFF
--- a/lib/ClassLoader.php
+++ b/lib/ClassLoader.php
@@ -33,7 +33,7 @@ class ClassLoader extends \Composer\Autoload\ClassLoader {
         if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
           $old = require __DIR__ . '/../vendor/autoload.php';
         } elseif (file_exists(__DIR__ . '/../../../autoload.php')) {
-          $old = require __DIR__ . '/../../../vendor/autoload.php';
+          $old = require __DIR__ . '/../../../autoload.php';
         } else {
           throw new \RuntimeException("Can't find composer root, unable to hijack autoloader");
         }


### PR DESCRIPTION
Prior to this patch this code checked for `autoload.php` but then tried to require `vendor/autoload.php`. I changed the string passed to `require` to match the string passed to `file_exists`.

Without this change I would get a fatal error as phack would `require` a file that didn't exist.
